### PR TITLE
Add an early return for unknown CC events

### DIFF
--- a/device_akai_mpk_mini_plus.py
+++ b/device_akai_mpk_mini_plus.py
@@ -32,4 +32,6 @@ def OnControlChange(event):
         elif event.data1 == BUTTON_RECORD:
             print(f'{"Disabled" if transport.isRecording() else "Enabled"} recording')
             transport.record()
+        else:
+            return
         event.handled = True


### PR DESCRIPTION
This prevents these events from being handled, which was causing them to only be used for automation when the value was zero (as per line 16). It's not the cleanest solution, but I'm expecting that a lot of this will be rewritten as you improve and build upon the script, so I won't step on your toes with your design.